### PR TITLE
#64 Add ability to update and create new secrets

### DIFF
--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -42,7 +42,7 @@
 
 
   <ItemGroup>
-	<PackageReference Include="Avalonia.Desktop" Version="11.1.0-beta2" />
+	<PackageReference Include="Avalonia.Desktop" Version="11.1.0-rc2" />
   </ItemGroup>
 
   	

--- a/KeyVaultExplorer/Exceptions/KvExceptions.cs
+++ b/KeyVaultExplorer/Exceptions/KvExceptions.cs
@@ -18,3 +18,37 @@ public class KeyVaultItemNotFoundException : Exception
     {
     }
 }
+
+public class KeyVaultItemNotFailedToUpdate : Exception
+{
+    public KeyVaultItemNotFailedToUpdate()
+    {
+    }
+
+    public KeyVaultItemNotFailedToUpdate(string message)
+        : base(message)
+    {
+    }
+
+    public KeyVaultItemNotFailedToUpdate(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}
+
+public class KeyVaultInSufficientPrivileges : Exception
+{
+    public KeyVaultInSufficientPrivileges()
+    {
+    }
+
+    public KeyVaultInSufficientPrivileges(string message)
+        : base(message)
+    {
+    }
+
+    public KeyVaultInSufficientPrivileges(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/KeyVaultExplorer/KeyVaultExplorer.csproj
+++ b/KeyVaultExplorer/KeyVaultExplorer.csproj
@@ -42,16 +42,16 @@
 
 
   <ItemGroup>
-	<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.0-beta2" />
-    <PackageReference Include="Avalonia.Svg.Skia" Version="11.1.0-beta1" />
+	<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.0-rc2" />
+    <PackageReference Include="Avalonia.Svg.Skia" Version="11.1.0-rc1" />
     <PackageReference Include="DeviceId" Version="6.6.0" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.1.0-preview5" />
+    <PackageReference Include="FluentAvaloniaUI" Version="2.1.0-preview6" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0-beta2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.4.24266.19" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.0-preview.4.24267.1" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0-rc2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.5.24306.7" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.0-preview.5.24306.3" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0-preview.4.24266.19" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0-preview.5.24306.7" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
@@ -91,6 +91,12 @@
 	    <Pack>True</Pack>
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </AvaloniaResource>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Compile Update="Views\Pages\PropertiesDialogs\CreateNewSecretVersion.axaml.cs">
+	    <DependentUpon>CreateNewSecretVersion.axaml</DependentUpon>
+	  </Compile>
 	</ItemGroup>
 
 

--- a/KeyVaultExplorer/Models/AppSettings.cs
+++ b/KeyVaultExplorer/Models/AppSettings.cs
@@ -12,4 +12,6 @@ public class AppSettings
 
     [AllowedValues("Inline", "Overlay")]
     public string SplitViewDisplayMode { get; set; } = "Inline";
+    public string PanePlacement { get; set; } = "Left";
+
 }

--- a/KeyVaultExplorer/Resources/Resources.axaml
+++ b/KeyVaultExplorer/Resources/Resources.axaml
@@ -4,7 +4,10 @@
     xmlns:ui="using:FluentAvalonia.UI.Controls">
 
 
-    <SolidColorBrush x:Key="DynamicActiveBackgroundFAColor" Color="{DynamicResource SolidBackgroundFillColorBase}" />
+
+
+
+	<SolidColorBrush x:Key="DynamicActiveBackgroundFAColor" Color="{DynamicResource SolidBackgroundFillColorBase}" />
     <!--<StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="SelectedTabViewColorKv" />
     <SolidColorBrush x:Key="SelectedTabViewColorKv" Color="Transparent" />-->
 

--- a/KeyVaultExplorer/Resources/Styles.axaml
+++ b/KeyVaultExplorer/Resources/Styles.axaml
@@ -5,12 +5,19 @@
     xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">
     <Design.PreviewWith />
 
-    <Style Selector="TextBox">
+    <Style Selector="TextBox.IsSmall">
         <Setter Property="MinHeight" Value="30" />
         <Setter Property="MaxHeight" Value="30" />
         <Setter Property="Height" Value="30" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="Padding" Value="8,2,2,2" />
+    </Style>
+
+    <Style Selector="TextBox.isCompact">
+        <Setter Property="MinHeight" Value="25" />
+        <Setter Property="Padding" Value="5,0,0,0" />
+        <Setter Property="FontSize" Value="{DynamicResource FontSizeSmall}" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
     <Style Selector="ui|CommandBarFlyoutCommandBar /template/ Border#LayoutRoot">

--- a/KeyVaultExplorer/ViewModels/CreateNewSecretVersionViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/CreateNewSecretVersionViewModel.cs
@@ -1,0 +1,106 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using KeyVaultExplorer.Views;
+using KeyVaultExplorer.Services;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Linq;
+using Azure.Security.KeyVault.Secrets;
+using System;
+
+namespace KeyVaultExplorer.ViewModels;
+
+public partial class CreateNewSecretVersionViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private bool isBusy = false;
+
+    [ObservableProperty]
+    private bool isEdit = false;
+
+    public bool HasActivationDate => KeyVaultSecretModel is not null && KeyVaultSecretModel.NotBefore.HasValue;
+    public bool HasExpirationDate => KeyVaultSecretModel is not null && KeyVaultSecretModel.ExpiresOn.HasValue;
+
+    [ObservableProperty]
+    private string secretValue;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Location))]
+    [NotifyPropertyChangedFor(nameof(HasActivationDate))]
+    [NotifyPropertyChangedFor(nameof(HasExpirationDate))]
+    private SecretProperties keyVaultSecretModel;
+
+    [ObservableProperty]
+    private TimeSpan? expiresOnTimespan;// => KeyVaultSecretModel is not null && KeyVaultSecretModel.ExpiresOn.HasValue ? KeyVaultSecretModel?.ExpiresOn.Value.LocalDateTime.TimeOfDay : null;
+
+    [ObservableProperty]
+    private TimeSpan? notBeforeTimespan;
+
+    public string? Location => KeyVaultSecretModel?.VaultUri.ToString();
+    public string? Identifier => KeyVaultSecretModel?.Id.ToString();
+
+    private readonly AuthService _authService;
+    private readonly VaultService _vaultService;
+    private NotificationViewModel _notificationViewModel;
+
+    public CreateNewSecretVersionViewModel()
+    {
+        _authService = Defaults.Locator.GetRequiredService<AuthService>();
+        _vaultService = Defaults.Locator.GetRequiredService<VaultService>();
+        _notificationViewModel = Defaults.Locator.GetRequiredService<NotificationViewModel>();
+    }
+
+    [RelayCommand]
+    public async Task EditDetails()
+    {
+
+        if (KeyVaultSecretModel.NotBefore.HasValue)
+        {
+            var time = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
+            KeyVaultSecretModel.NotBefore = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
+        }
+
+        if (KeyVaultSecretModel.ExpiresOn.HasValue)
+            KeyVaultSecretModel.ExpiresOn = KeyVaultSecretModel.ExpiresOn.Value.Date + (ExpiresOnTimespan.HasValue ? ExpiresOnTimespan.Value : TimeSpan.Zero);
+
+       var updatedProps =  await _vaultService.UpdateSecret(KeyVaultSecretModel, KeyVaultSecretModel.VaultUri);
+        KeyVaultSecretModel = updatedProps;
+
+    }
+
+    [RelayCommand]
+    public async Task NewVersion()
+    {
+
+
+        var newSecret = new KeyVaultSecret(KeyVaultSecretModel.Name, SecretValue);
+        if (KeyVaultSecretModel.NotBefore.HasValue)
+        {
+            var time = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
+            newSecret.Properties.NotBefore = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
+        }
+
+        if (KeyVaultSecretModel.ExpiresOn.HasValue)
+            newSecret.Properties.ExpiresOn = KeyVaultSecretModel.ExpiresOn.Value.Date + (ExpiresOnTimespan.HasValue ? ExpiresOnTimespan.Value : TimeSpan.Zero);
+
+        newSecret.Properties.ContentType = KeyVaultSecretModel.ContentType;
+        newSecret.Properties.Tags = KeyVaultSecretModel.Tags;
+
+        var newVersion = await _vaultService.CreateSecret(newSecret, KeyVaultSecretModel.VaultUri);
+        var properties = (await _vaultService.GetSecretProperties(newVersion.Properties.VaultUri, newVersion.Name)).First();
+        KeyVaultSecretModel = properties;
+
+
+    }
+
+
+    partial void OnKeyVaultSecretModelChanging(SecretProperties model)
+    {
+        ExpiresOnTimespan = model is not null && model.ExpiresOn.HasValue ? model?.ExpiresOn.Value.LocalDateTime.TimeOfDay : null;
+        NotBeforeTimespan = model is not null && model.NotBefore.HasValue ? model?.NotBefore.Value.LocalDateTime.TimeOfDay : null;
+    }
+
+
+}

--- a/KeyVaultExplorer/ViewModels/CreateNewSecretVersionViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/CreateNewSecretVersionViewModel.cs
@@ -33,7 +33,7 @@ public partial class CreateNewSecretVersionViewModel : ViewModelBase
     private SecretProperties keyVaultSecretModel;
 
     [ObservableProperty]
-    private TimeSpan? expiresOnTimespan;// => KeyVaultSecretModel is not null && KeyVaultSecretModel.ExpiresOn.HasValue ? KeyVaultSecretModel?.ExpiresOn.Value.LocalDateTime.TimeOfDay : null;
+    private TimeSpan? expiresOnTimespan;
 
     [ObservableProperty]
     private TimeSpan? notBeforeTimespan;
@@ -55,52 +55,36 @@ public partial class CreateNewSecretVersionViewModel : ViewModelBase
     [RelayCommand]
     public async Task EditDetails()
     {
-
         if (KeyVaultSecretModel.NotBefore.HasValue)
-        {
-            var time = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
             KeyVaultSecretModel.NotBefore = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
-        }
 
         if (KeyVaultSecretModel.ExpiresOn.HasValue)
             KeyVaultSecretModel.ExpiresOn = KeyVaultSecretModel.ExpiresOn.Value.Date + (ExpiresOnTimespan.HasValue ? ExpiresOnTimespan.Value : TimeSpan.Zero);
 
-       var updatedProps =  await _vaultService.UpdateSecret(KeyVaultSecretModel, KeyVaultSecretModel.VaultUri);
+        var updatedProps = await _vaultService.UpdateSecret(KeyVaultSecretModel, KeyVaultSecretModel.VaultUri);
         KeyVaultSecretModel = updatedProps;
-
     }
 
     [RelayCommand]
     public async Task NewVersion()
     {
-
-
         var newSecret = new KeyVaultSecret(KeyVaultSecretModel.Name, SecretValue);
         if (KeyVaultSecretModel.NotBefore.HasValue)
-        {
-            var time = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
             newSecret.Properties.NotBefore = KeyVaultSecretModel.NotBefore.Value.Date + (NotBeforeTimespan.HasValue ? NotBeforeTimespan.Value : TimeSpan.Zero);
-        }
 
         if (KeyVaultSecretModel.ExpiresOn.HasValue)
             newSecret.Properties.ExpiresOn = KeyVaultSecretModel.ExpiresOn.Value.Date + (ExpiresOnTimespan.HasValue ? ExpiresOnTimespan.Value : TimeSpan.Zero);
 
         newSecret.Properties.ContentType = KeyVaultSecretModel.ContentType;
-        newSecret.Properties.Tags = KeyVaultSecretModel.Tags;
 
         var newVersion = await _vaultService.CreateSecret(newSecret, KeyVaultSecretModel.VaultUri);
         var properties = (await _vaultService.GetSecretProperties(newVersion.Properties.VaultUri, newVersion.Name)).First();
         KeyVaultSecretModel = properties;
-
-
     }
-
 
     partial void OnKeyVaultSecretModelChanging(SecretProperties model)
     {
         ExpiresOnTimespan = model is not null && model.ExpiresOn.HasValue ? model?.ExpiresOn.Value.LocalDateTime.TimeOfDay : null;
         NotBeforeTimespan = model is not null && model.NotBefore.HasValue ? model?.NotBefore.Value.LocalDateTime.TimeOfDay : null;
     }
-
-
 }

--- a/KeyVaultExplorer/ViewModels/NotificationViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/NotificationViewModel.cs
@@ -1,7 +1,10 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Notifications;
 using FluentAvalonia.UI.Controls;
-using System;
+using FluentAvalonia.UI.Windowing;
+using System.Linq;
 
 namespace KeyVaultExplorer.ViewModels;
 
@@ -16,21 +19,19 @@ public class NotificationViewModel
 
     public async void ShowErrorPopup(Notification notification)
     {
-        // Declaring a TaskDialog from C#:
         var td = new TaskDialog
         {
-            // Title property only applies on Windowed dialogs
             Title = notification.Title,
             Header = notification.Title,
             Content = notification.Message,
-            //IconSource = new SymbolIconSource { Symbol = Symbol.clos },
-            FooterVisibility = TaskDialogFooterVisibility.Auto,
-            //Footer = new CheckBox { Content = "Never show me this again" },
+            FooterVisibility = TaskDialogFooterVisibility.Always,
+            IsFooterExpanded = false,
+            Buttons = { TaskDialogButton.CloseButton },
 
-            Buttons = { TaskDialogButton.CloseButton }
         };
-        td.XamlRoot = App.Current.GetTopLevel();
-
-        var result = await td.ShowAsync();
+          //Avalonia.Application.Current.GetTopLevel() as AppWindow;
+        var lifetime = App.Current.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime;
+        td.XamlRoot = lifetime.Windows.Last() as AppWindow;
+        await td.ShowAsync(true);
     }
 }

--- a/KeyVaultExplorer/ViewModels/VaultPageViewModel.cs
+++ b/KeyVaultExplorer/ViewModels/VaultPageViewModel.cs
@@ -396,18 +396,18 @@ public partial class VaultPageViewModel : ViewModelBase
             Icon = BitmapImage,
             SizeToContent = SizeToContent.Manual,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
-            ShowAsDialog = false,
+            ShowAsDialog = true,
             CanResize = true,
             Content = new PropertiesPage { DataContext = new PropertiesPageViewModel(model) },
-            Width = 620,
-            Height = 480,
-            MinWidth = 300,
+            Width = 820,
+            Height = 680,
+            Topmost = false,
             ExtendClientAreaToDecorationsHint = true,
             // TransparencyLevelHint = new List<WindowTransparencyLevel>() { WindowTransparencyLevel.Mica, WindowTransparencyLevel.AcrylicBlur },
             // Background = null,
         };
 
         var topLevel = Avalonia.Application.Current.GetTopLevel() as AppWindow;
-        taskDialog.Show(topLevel);
+        taskDialog.ShowDialog(topLevel);
     }
 }

--- a/KeyVaultExplorer/Views/CustomControls/KeyVaultTreeList.axaml
+++ b/KeyVaultExplorer/Views/CustomControls/KeyVaultTreeList.axaml
@@ -135,6 +135,7 @@
                 HorizontalAlignment="Stretch"
                 VerticalContentAlignment="Center"
                 AcceptsReturn="False"
+                Classes.IsSmall="True"
                 Classes.clearButton="True"
                 FontSize="{StaticResource FontSizeSmall}"
                 IsEnabled="{Binding !IsBusy}"

--- a/KeyVaultExplorer/Views/Pages/PropertiesDialogs/CreateNewSecretVersion.axaml
+++ b/KeyVaultExplorer/Views/Pages/PropertiesDialogs/CreateNewSecretVersion.axaml
@@ -1,0 +1,126 @@
+<UserControl
+    x:Class="KeyVaultExplorer.CreateNewSecretVersion"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="clr-namespace:KeyVaultExplorer.ViewModels"
+    d:DesignHeight="450"
+    d:DesignWidth="600"
+    x:DataType="vm:CreateNewSecretVersionViewModel"
+    mc:Ignorable="d">
+
+
+    <ScrollViewer>
+        <StackPanel MinWidth="400" Margin="10">
+
+            <Grid ColumnDefinitions="*" RowDefinitions="*,*,*,*,*,*,*,*,*,*">
+                <!--      <StackPanel Grid.Row="0" Orientation="Vertical">
+                    <TextBlock
+                        Margin="0,0,10,0"
+                        VerticalAlignment="Center"
+                        Text="Secret Name" />
+                    <TextBox IsEnabled="{Binding Identifier, Converter={x:Static ObjectConverters.IsNull}}" Text="{Binding KeyVaultSecretModel.Name}" />
+                </StackPanel>
+
+
+                <StackPanel Grid.Row="2" Orientation="Vertical">
+                    <TextBlock
+                        Margin="0,0,10,0"
+                        VerticalAlignment="Center"
+                        Text="Secret Identifier" />
+                    <TextBox IsEnabled="{Binding Identifier, Converter={x:Static ObjectConverters.IsNull}}" Text="{Binding Identifier}" />
+                </StackPanel>
+
+
+                <StackPanel Grid.Row="1" Orientation="Vertical">
+                    <TextBlock
+                        Margin="0,0,10,0"
+                        VerticalAlignment="Center"
+                        Text="Vault Location:" />
+                    <TextBox IsEnabled="{Binding Identifier, Converter={x:Static ObjectConverters.IsNull}}" Text="{Binding Location}" />
+                </StackPanel>-->
+
+
+                <StackPanel Grid.Row="0">
+                    <CheckBox
+                        Name="SetActivationDateCheckbox"
+                        IsChecked="{Binding HasActivationDate}"
+                        ToolTip.Tip="Sets when this resource will become active. This sets the 'nbf' property on the resource. A new current but inactive version will still be created after this operation.">
+                        Set Activation Date
+                    </CheckBox>
+                    <StackPanel
+                        IsVisible="{Binding #SetActivationDateCheckbox.IsChecked}"
+                        Orientation="Vertical"
+                        Spacing="5">
+                        <DatePicker
+                            MinWidth="400"
+                            HorizontalAlignment="Left"
+                            SelectedDate="{Binding KeyVaultSecretModel.NotBefore}" />
+                        <TimePicker MinWidth="400" SelectedTime="{Binding NotBeforeTimespan}" />
+                    </StackPanel>
+                    <CheckBox
+                        Name="SetExpirationDateCheckbox"
+                        IsChecked="{Binding HasExpirationDate}"
+                        ToolTip.Tip="Sets when this resource will become inactive. This sets the 'exp' property on the resource.">
+                        Set Expiration Date
+                    </CheckBox>
+                    <StackPanel
+                        IsVisible="{Binding #SetExpirationDateCheckbox.IsChecked}"
+                        Orientation="Vertical"
+                        Spacing="5">
+                        <DatePicker MinWidth="400" SelectedDate="{Binding KeyVaultSecretModel.ExpiresOn}" />
+                        <TimePicker MinWidth="400" SelectedTime="{Binding ExpiresOnTimespan, Mode=TwoWay}" />
+                    </StackPanel>
+                </StackPanel>
+
+
+                <StackPanel
+                    Grid.Row="2"
+                    Orientation="Horizontal"
+                    Spacing="5">
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        VerticalAlignment="Center"
+                        Text="Enabled" />
+                    <ToggleSwitch
+                        IsChecked="{Binding KeyVaultSecretModel.Enabled}"
+                        OffContent="No"
+                        OnContent="Yes" />
+                </StackPanel>
+
+
+
+                <StackPanel
+                    Grid.Row="3"
+                    Orientation="Vertical"
+                    Spacing="5">
+                    <TextBlock VerticalAlignment="Center" Text="Secret Content type (optional)" />
+                    <TextBox Classes.IsSmall="True" Text="{Binding KeyVaultSecretModel.ContentType}" />
+                </StackPanel>
+
+
+                <StackPanel
+                    Grid.Row="4"
+                    Orientation="Vertical"
+                    Spacing="5">
+                    <TextBlock VerticalAlignment="Center" Text="Secret Value" />
+
+                    <TextBox
+                        Height="100"
+                        AcceptsReturn="True"
+                        AcceptsTab="True"
+                        IsEnabled="{Binding !IsEdit}"
+                        RevealPassword="True"
+                        Text="{Binding SecretValue}"
+                        TextWrapping="Wrap"
+                        Watermark="Enter the secret" />
+
+                </StackPanel>
+
+            </Grid>
+
+        </StackPanel>
+    </ScrollViewer>
+
+</UserControl>

--- a/KeyVaultExplorer/Views/Pages/PropertiesDialogs/CreateNewSecretVersion.axaml.cs
+++ b/KeyVaultExplorer/Views/Pages/PropertiesDialogs/CreateNewSecretVersion.axaml.cs
@@ -1,0 +1,27 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using KeyVaultExplorer.ViewModels;
+namespace KeyVaultExplorer;
+
+public partial class CreateNewSecretVersion : UserControl
+{
+    public CreateNewSecretVersion()
+    {
+        InitializeComponent();
+        DataContext = new CreateNewSecretVersionViewModel();
+    }
+
+    private void InputField_OnAttachedToVisualTree(object sender, VisualTreeAttachmentEventArgs e)
+    {
+        // We will set the focus into our input field just after it got attached to the visual tree.
+        if (sender is InputElement inputElement)
+        {
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                inputElement.Focus(NavigationMethod.Unspecified, KeyModifiers.None);
+            });
+        }
+    }
+}

--- a/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
@@ -28,6 +28,17 @@
                     <Setter Property="VerticalAlignment" Value="Bottom" />
                 </Style>
             </Style>
+
+            <Style Selector="Border.isInput">
+                <Setter Property="Background" Value="{DynamicResource LayerFillColorDefaultBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="4" />
+                <Style Selector="^ SelectableTextBlock">
+                    <Setter Property="Margin" Value="5,0" />
+                </Style>
+            </Style>
+
         </Styles>
     </UserControl.Styles>
 
@@ -57,13 +68,34 @@
                     ToolTip.VerticalOffset="10" />
                 <ui:CommandBarButton
                     Height="40"
+                    VerticalContentAlignment="Center"
                     Command="{Binding CopyCommand}"
                     IconSource="Copy"
                     IsVisible="{Binding !IsCertificate}"
                     Label="Copy"
-                    VerticalContentAlignment="Center"
-                    ToolTip.Tip="Copy Value (cleared after 30 seconds) "
+                    ToolTip.Tip="Copy Value (cleared after configured seconds)"
                     ToolTip.VerticalOffset="10" />
+
+                <ui:CommandBarButton
+                    Height="40"
+                    VerticalContentAlignment="Center"
+                    Command="{Binding EditVersionCommand}"
+                    IconSource="Edit"
+                    IsEnabled="{Binding !IsManaged}"
+                    Label="Edit"
+                    ToolTip.Tip="Edit Current Version"
+                    ToolTip.VerticalOffset="10" />
+
+                <ui:CommandBarButton
+                    Height="40"
+                    VerticalContentAlignment="Center"
+                    Command="{Binding NewVersionCommand}"
+                    IconSource="Add"
+                    IsEnabled="{Binding !IsManaged}"
+                    Label="New Version"
+                    ToolTip.Tip="Create New Version"
+                    ToolTip.VerticalOffset="10" />
+
                 <ui:CommandBarButton
                     Height="40"
                     Command="{Binding DownloadCommand}"
@@ -130,7 +162,7 @@
                                     FontSize="20"
                                     IsChecked="{Binding ShowValue}"
                                     RenderOptions.TextRenderingMode="Antialias"
-                                    Theme="{StaticResource TransparentButton}"
+                                    Theme="{StaticResource TransparentToggleButton}"
                                     ToolTip.Tip="Show/Hide"
                                     ToolTip.VerticalOffset="10"
                                     ZIndex="1" />
@@ -154,12 +186,13 @@
                             BorderThickness="1"
                             CornerRadius="4">
                             <ScrollViewer VerticalScrollBarVisibility="Visible">
-                                <StackPanel MaxHeight="300" VerticalAlignment="Stretch">
+                                <StackPanel  VerticalAlignment="Stretch">
                                     <TextBlock Text="Properties" Theme="{StaticResource BodyStrongTextBlockStyle}" />
                                     <Grid
                                         HorizontalAlignment="Stretch"
-                                        ColumnDefinitions="100,*"
-                                        RowDefinitions="*,*,*,*">
+                                        VerticalAlignment="Stretch"
+                                        ColumnDefinitions="250,*"
+                                        RowDefinitions="*,*,*,*,*,*,*">
                                         <Grid.Styles>
                                             <Style Selector="TextBlock">
                                                 <Setter Property="Theme" Value="{StaticResource CaptionTextBlockStyle}" />
@@ -168,39 +201,73 @@
                                         <TextBlock
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Text="Created:" />
-                                        <TextBlock
-                                            Grid.Row="1"
-                                            Grid.Column="0"
-                                            Text="Updated:" />
-                                        <TextBlock
-                                            Grid.Row="2"
-                                            Grid.Column="0"
-                                            Text="Identifier:" />
-                                        <TextBlock
-                                            Grid.Row="3"
-                                            Grid.Column="0"
-                                            Text="Expires:" />
+                                            Text="Name:" />
                                         <SelectableTextBlock
                                             Grid.Row="0"
                                             Grid.Column="1"
                                             xml:space="preserve"
-                                            Text="{Binding OpenedItem.CreatedOn}" />
+                                            Text="{Binding OpenedItem.Name}" />
+
+                                        <TextBlock
+                                            Grid.Row="1"
+                                            Grid.Column="0"
+                                            Text="Location:" />
                                         <SelectableTextBlock
                                             Grid.Row="1"
                                             Grid.Column="1"
                                             xml:space="preserve"
-                                            Text="{Binding OpenedItem.UpdatedOn}" />
+                                            Text="{Binding OpenedItem.VaultUri}" />
+
+                                        <TextBlock
+                                            Grid.Row="2"
+                                            Grid.Column="0"
+                                            Text="Identifier:" />
                                         <SelectableTextBlock
                                             Grid.Row="2"
                                             Grid.Column="1"
                                             xml:space="preserve"
                                             Text="{Binding OpenedItem.Id}" />
+
+                                        <TextBlock
+                                            Grid.Row="3"
+                                            Grid.Column="0"
+                                            Text="Activation:" />
                                         <SelectableTextBlock
                                             Grid.Row="3"
                                             Grid.Column="1"
                                             xml:space="preserve"
+                                            Text="{Binding OpenedItem.NotBefore}" />
+
+                                        <TextBlock
+                                            Grid.Row="4"
+                                            Grid.Column="0"
+                                            Text="Expiration:" />
+                                        <SelectableTextBlock
+                                            Grid.Row="4"
+                                            Grid.Column="1"
+                                            xml:space="preserve"
                                             Text="{Binding OpenedItem.ExpiresOn}" />
+
+                                        <TextBlock
+                                            Grid.Row="5"
+                                            Grid.Column="0"
+                                            Text="Created:" />
+                                        <SelectableTextBlock
+                                            Grid.Row="5"
+                                            Grid.Column="1"
+                                            xml:space="preserve"
+                                            Text="{Binding OpenedItem.CreatedOn}" />
+
+                                        <TextBlock
+                                            Grid.Row="6"
+                                            Grid.Column="0"
+                                            Text="Updated:" />
+                                        <SelectableTextBlock
+                                            Grid.Row="6"
+                                            Grid.Column="1"
+                                            xml:space="preserve"
+                                            Text="{Binding OpenedItem.UpdatedOn}" />
+
                                     </Grid>
 
 

--- a/KeyVaultExplorer/Views/Pages/TabViewPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/TabViewPage.axaml
@@ -27,6 +27,8 @@
             </Style>
         </Styles>
     </UserControl.Styles>
+    <!--  PanePlacement="Right"  -->
+
     <SplitView
         Name="VaultListSplitView"
         VerticalAlignment="Stretch"

--- a/KeyVaultExplorer/Views/Pages/VaultPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/VaultPage.axaml
@@ -122,6 +122,7 @@
                     HorizontalAlignment="Stretch"
                     VerticalContentAlignment="Center"
                     AcceptsReturn="False"
+                    Classes.IsSmall="True"
                     Classes.clearButton="True"
                     ClipToBounds="True"
                     DockPanel.Dock="Right"


### PR DESCRIPTION
This adds two new buttons. Edit and New Version on the properties page. If the secret is editable, then you will get a modal with options to edit the properties which you can actually update, all but the secret value. 




![image](https://github.com/cricketthomas/AzureKeyVaultExplorer/assets/15821271/c68e5b86-8e8a-4329-986b-775df3b75d8b)
![image](https://github.com/cricketthomas/AzureKeyVaultExplorer/assets/15821271/998b685a-79dc-466d-a3e4-b75a3481f4be)
![image](https://github.com/cricketthomas/AzureKeyVaultExplorer/assets/15821271/7b21bfac-68d8-42d4-9d36-f86387ebc4da)
![image](https://github.com/cricketthomas/AzureKeyVaultExplorer/assets/15821271/b760f175-c940-4e72-8061-a39604c062cd)


This also adds a new error dialog:
![image](https://github.com/cricketthomas/AzureKeyVaultExplorer/assets/15821271/dbb4ab94-332d-4332-b025-71bc0eb1522c)

